### PR TITLE
Remove incident map reference

### DIFF
--- a/src/app/[locale]/incident/page.tsx
+++ b/src/app/[locale]/incident/page.tsx
@@ -14,13 +14,6 @@ function IncidentDescriptionPage() {
     <>
       <div className="flex flex-col gap-4">
         <h1>{t('heading')}</h1>
-        <p>
-          {t.rich('description', {
-            link: (chunks) => (
-              <LinkWrapper href={'/notifications-map'}>{chunks}</LinkWrapper>
-            ),
-          })}
-        </p>
         <NextIntlClientProvider messages={messages}>
           <IncidentDescriptionForm />
         </NextIntlClientProvider>

--- a/src/routing/navigation.ts
+++ b/src/routing/navigation.ts
@@ -6,10 +6,6 @@ export const locales = getAllAvailableLocales()
 
 export const pathnames = {
   '/': '/',
-  '/notifications-map': {
-    en: '/notifications-map',
-    nl: '/meldingen-kaart',
-  },
   '/incident': {
     en: '/incident',
     nl: '/incident',

--- a/translations/en.json
+++ b/translations/en.json
@@ -11,7 +11,6 @@
   },
   "describe-report": {
     "heading": "1. Describe your report",
-    "description": "Before you file a notification, you can see which notifications are known to the municipality on the <link>notifications map</link>. Is your notification not listed? Then make a notification.",
     "form": {
       "describe_textarea_heading": "What is it about?",
       "describe_textarea_description": "Do not type personal information in this description. We will ask this of you later in this form.",

--- a/translations/nl.json
+++ b/translations/nl.json
@@ -11,7 +11,6 @@
   },
   "describe-report": {
     "heading": "1. Beschrijf uw melding",
-    "description": "Voordat u een melding doet kunt u op de <link>meldingenkaart</link> zien welke meldingen bekend zijn bij de gemeente. Staat uw melding er niet bij? Maak dan een melding.",
     "form": {
       "describe_textarea_heading": "Waar gaat het om?",
       "describe_textarea_description": "Typ geen persoonsgegevens in deze omschrijving. We vragen dit later in dit formulier aan u.",


### PR DESCRIPTION
This change removes the incident map reference, as we will not implement this for now.