### PR TITLE
Fix: eslint 9 upgrade, migration from eslintrc to eslint.config.mjs

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,4 +1,0 @@
-{
-  "extends": ["next/core-web-vitals", "plugin:prettier/recommended"]
-}
-

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,13 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import js from "@eslint/js";
+import { FlatCompat } from "@eslint/eslintrc";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const compat = new FlatCompat({
+    baseDirectory: __dirname,
+    recommendedConfig: js.configs.recommended,
+    allConfig: js.configs.all
+});
+export default [...compat.extends("next/core-web-vitals", "plugin:prettier/recommended")];


### PR DESCRIPTION
Eslint v8.x is EOL per 05-10-2024, so upgraded Eslint to v9.x, .eslintrc.json is not supported anymore in Eslint v9.x so had to migrate this to eslint.config.mjs