### PR TITLE
Feat/54 HeadingGroup + 55 Metadata

### DIFF
--- a/src/app/[locale]/incident/add/page.tsx
+++ b/src/app/[locale]/incident/add/page.tsx
@@ -1,6 +1,30 @@
 import { NextIntlClientProvider, useMessages, useTranslations } from 'next-intl'
 import { IncidentQuestionsLocationForm } from '@/app/[locale]/incident/add/components/IncidentQuestionsLocationForm'
 import { Heading, HeadingGroup, PreHeading } from '@/components/index'
+import { getTranslations } from 'next-intl/server'
+import { createTitle } from '@/lib/utils/create-title'
+import { Metadata } from 'next/types'
+
+const currentStep = 2
+const maxStep = 4
+
+export async function generateMetadata(): Promise<Metadata> {
+  const errorMessage = ''
+  const t = await getTranslations('describe-add')
+  const tGeneral = await getTranslations('general.describe_form')
+
+  return {
+    title: createTitle(
+      [
+        errorMessage ? tGeneral('title-prefix-error') : '',
+        tGeneral('pre-heading', { current: currentStep, max: maxStep }),
+        t('heading'),
+        'gemeente Voorbeeld',
+      ],
+      tGeneral('title-separator')
+    ),
+  }
+}
 
 export default function AddAditionalInformationPage() {
   const t = useTranslations('describe-add')
@@ -12,7 +36,7 @@ export default function AddAditionalInformationPage() {
       <HeadingGroup>
         <Heading level={1}>{t('heading')}</Heading>
         <PreHeading>
-          {tGeneral('pre-heading', { current: 2, max: 4 })}
+          {tGeneral('pre-heading', { current: currentStep, max: maxStep })}
         </PreHeading>
       </HeadingGroup>
       <NextIntlClientProvider messages={messages}>

--- a/src/app/[locale]/incident/add/page.tsx
+++ b/src/app/[locale]/incident/add/page.tsx
@@ -1,14 +1,20 @@
 import { NextIntlClientProvider, useMessages, useTranslations } from 'next-intl'
 import { IncidentQuestionsLocationForm } from '@/app/[locale]/incident/add/components/IncidentQuestionsLocationForm'
-import { Heading } from '@/components/index'
+import { Heading, HeadingGroup, PreHeading } from '@/components/index'
 
 export default function AddAditionalInformationPage() {
   const t = useTranslations('describe-add')
+  const tGeneral = useTranslations('general.describe_form')
   const messages = useMessages()
 
   return (
     <div className="flex flex-col gap-4">
-      <Heading level={1}>{t('heading')}</Heading>
+      <HeadingGroup>
+        <Heading level={1}>{t('heading')}</Heading>
+        <PreHeading>
+          {tGeneral('pre-heading', { current: 2, max: 4 })}
+        </PreHeading>
+      </HeadingGroup>
       <NextIntlClientProvider messages={messages}>
         <IncidentQuestionsLocationForm />
       </NextIntlClientProvider>

--- a/src/app/[locale]/incident/contact/page.tsx
+++ b/src/app/[locale]/incident/contact/page.tsx
@@ -1,6 +1,30 @@
 import { NextIntlClientProvider, useMessages, useTranslations } from 'next-intl'
 import { IncidentContactForm } from '@/app/[locale]/incident/contact/components/IncidentContactForm'
 import { Heading, HeadingGroup, PreHeading } from '@/components/index'
+import { getTranslations } from 'next-intl/server'
+import { createTitle } from '@/lib/utils/create-title'
+import { Metadata } from 'next/types'
+
+const currentStep = 3
+const maxStep = 4
+
+export async function generateMetadata(): Promise<Metadata> {
+  const errorMessage = ''
+  const t = await getTranslations('describe-contact')
+  const tGeneral = await getTranslations('general.describe_form')
+
+  return {
+    title: createTitle(
+      [
+        errorMessage ? tGeneral('title-prefix-error') : '',
+        tGeneral('pre-heading', { current: currentStep, max: maxStep }),
+        t('heading'),
+        'gemeente Voorbeeld',
+      ],
+      tGeneral('title-separator')
+    ),
+  }
+}
 
 export default function AddContactDetailsPage() {
   const t = useTranslations('describe-contact')
@@ -12,7 +36,7 @@ export default function AddContactDetailsPage() {
       <HeadingGroup>
         <Heading level={1}>{t('heading')}</Heading>
         <PreHeading>
-          {tGeneral('pre-heading', { current: 3, max: 4 })}
+          {tGeneral('pre-heading', { current: currentStep, max: maxStep })}
         </PreHeading>
       </HeadingGroup>
       <NextIntlClientProvider messages={messages}>

--- a/src/app/[locale]/incident/contact/page.tsx
+++ b/src/app/[locale]/incident/contact/page.tsx
@@ -1,14 +1,20 @@
 import { NextIntlClientProvider, useMessages, useTranslations } from 'next-intl'
 import { IncidentContactForm } from '@/app/[locale]/incident/contact/components/IncidentContactForm'
-import { Heading } from '@/components/index'
+import { Heading, HeadingGroup, PreHeading } from '@/components/index'
 
 export default function AddContactDetailsPage() {
   const t = useTranslations('describe-contact')
+  const tGeneral = useTranslations('general.describe_form')
   const messages = useMessages()
 
   return (
     <div className="flex flex-col gap-4">
-      <Heading level={1}>{t('heading')}</Heading>
+      <HeadingGroup>
+        <Heading level={1}>{t('heading')}</Heading>
+        <PreHeading>
+          {tGeneral('pre-heading', { current: 3, max: 4 })}
+        </PreHeading>
+      </HeadingGroup>
       <NextIntlClientProvider messages={messages}>
         <IncidentContactForm />
       </NextIntlClientProvider>

--- a/src/app/[locale]/incident/page.tsx
+++ b/src/app/[locale]/incident/page.tsx
@@ -1,24 +1,43 @@
 import { NextIntlClientProvider, useMessages, useTranslations } from 'next-intl'
+import { getTranslations } from 'next-intl/server'
 import { IncidentDescriptionForm } from '@/app/[locale]/incident/components/IncidentDescriptionForm'
-import { Alert, HeadingGroup, PreHeading, Link } from '@/components/index'
+import {
+  Alert,
+  Heading,
+  HeadingGroup,
+  Paragraph,
+  PreHeading,
+  Link,
+} from '@/components/index'
+import { createTitle } from '@/lib/utils/create-title'
+import { Metadata } from 'next/types'
 
-import { Paragraph, Heading } from '@/components/index'
-// import { Metadata, ResolvingMetadata } from 'next/types'
+// TODO: Consider if these should be static params
+const currentStep = 1
+const maxStep = 4
 
-// type Props = {
-//   params: Promise<object>
-//   searchParams: Promise<{ [key: string]: string | string[] | undefined }>
-// }
+export async function generateMetadata(): Promise<Metadata> {
+  // TODO: Somehow obtain errorMessage status, or remove this code.
+  // Trying to achieve this prefix because of NL Design System guidelines:
+  // "Update het <title> element in de <head>"
+  // https://nldesignsystem.nl/richtlijnen/formulieren/foutmeldingen/screenreaderfeedback
+  const errorMessage = ''
 
-// export async function generateMetadata(
-//   { params, searchParams }: Props,
-//   parent: ResolvingMetadata
-// ): Promise<Metadata> {
-//   const t = useTranslations('describe-report')
-//   return {
-//     title: [t('heading'), 'Gemeente Purmerend'].join(' · '),
-//   }
-// }
+  const t = await getTranslations('describe-report')
+  const tGeneral = await getTranslations('general.describe_form')
+
+  return {
+    title: createTitle(
+      [
+        errorMessage ? tGeneral('title-prefix-error') : '',
+        tGeneral('pre-heading', { current: currentStep, max: maxStep }),
+        t('heading'),
+        'gemeente Voorbeeld',
+      ],
+      tGeneral('title-separator')
+    ),
+  }
+}
 
 export default async function Home() {
   return <IncidentDescriptionPage />
@@ -27,6 +46,7 @@ export default async function Home() {
 function IncidentDescriptionPage() {
   const t = useTranslations('describe-report')
   const tGeneral = useTranslations('general.describe_form')
+  const errorMessage = ''
   const messages = useMessages()
 
   return (
@@ -35,7 +55,7 @@ function IncidentDescriptionPage() {
         <HeadingGroup>
           <Heading level={1}>{t('heading')}</Heading>
           <PreHeading>
-            {tGeneral('pre-heading', { current: 1, max: 4 })}
+            {tGeneral('pre-heading', { current: currentStep, max: maxStep })}
           </PreHeading>
         </HeadingGroup>
         <Alert>

--- a/src/app/[locale]/incident/page.tsx
+++ b/src/app/[locale]/incident/page.tsx
@@ -1,8 +1,24 @@
 import { NextIntlClientProvider, useMessages, useTranslations } from 'next-intl'
 import { IncidentDescriptionForm } from '@/app/[locale]/incident/components/IncidentDescriptionForm'
-import { Alert, Link } from '@utrecht/component-library-react/dist/css-module'
+import { Alert, HeadingGroup, PreHeading, Link } from '@/components/index'
 
 import { Paragraph, Heading } from '@/components/index'
+// import { Metadata, ResolvingMetadata } from 'next/types'
+
+// type Props = {
+//   params: Promise<object>
+//   searchParams: Promise<{ [key: string]: string | string[] | undefined }>
+// }
+
+// export async function generateMetadata(
+//   { params, searchParams }: Props,
+//   parent: ResolvingMetadata
+// ): Promise<Metadata> {
+//   const t = useTranslations('describe-report')
+//   return {
+//     title: [t('heading'), 'Gemeente Purmerend'].join(' · '),
+//   }
+// }
 
 export default async function Home() {
   return <IncidentDescriptionPage />
@@ -10,12 +26,18 @@ export default async function Home() {
 
 function IncidentDescriptionPage() {
   const t = useTranslations('describe-report')
+  const tGeneral = useTranslations('general.describe_form')
   const messages = useMessages()
 
   return (
     <>
       <div className="flex flex-col gap-4">
-        <Heading level={1}>{t('heading')}</Heading>
+        <HeadingGroup>
+          <Heading level={1}>{t('heading')}</Heading>
+          <PreHeading>
+            {tGeneral('pre-heading', { current: 1, max: 4 })}
+          </PreHeading>
+        </HeadingGroup>
         <Alert>
           <Paragraph>
             Lukt het niet om een melding te doen? Bel het telefoonnummer

--- a/src/app/[locale]/incident/summary/components/IncidentSummaryForm.tsx
+++ b/src/app/[locale]/incident/summary/components/IncidentSummaryForm.tsx
@@ -81,11 +81,11 @@ const IncidentSummaryForm = () => {
 
   return (
     <div className="flex flex-col gap-8">
-      <Paragraph>{t('description')}</Paragraph>
+      <Paragraph appearance="lead">{t('description')}</Paragraph>
       <Divider />
       <div className="flex flex-col gap-4">
         <div className="flex flex-col gap-1 md:flex-row justify-between">
-          <Heading level={3}>{t('steps.step_one.title')}</Heading>
+          <Heading level={2}>{t('steps.step_one.title')}</Heading>
           <LinkWrapper href={'/incident'} onClick={() => goToStep(1)}>
             {t('steps.step_one.edit')}
           </LinkWrapper>
@@ -104,7 +104,7 @@ const IncidentSummaryForm = () => {
       <Divider />
       <div className="flex flex-col gap-4">
         <div className="flex flex-col gap-1 md:flex-row justify-between">
-          <Heading level={3}>{t('steps.step_two.title')}</Heading>
+          <Heading level={2}>{t('steps.step_two.title')}</Heading>
           <LinkWrapper href={'/incident/add'} onClick={() => goToStep(2)}>
             {t('steps.step_two.edit')}
           </LinkWrapper>
@@ -116,7 +116,7 @@ const IncidentSummaryForm = () => {
       <Divider />
       <div className="flex flex-col gap-4">
         <div className="flex flex-col gap-1 md:flex-row justify-between">
-          <Heading level={3}>{t('steps.step_three.title')}</Heading>
+          <Heading level={2}>{t('steps.step_three.title')}</Heading>
           <LinkWrapper href={'/incident/contact'} onClick={() => goToStep(3)}>
             {t('steps.step_three.edit')}
           </LinkWrapper>
@@ -164,7 +164,7 @@ export const IncidentSummaryFormItem = ({
 }) => {
   return (
     <div className="flex flex-col gap-1">
-      <Paragraph className="font-semibold">{title}</Paragraph>
+      <Heading level={3}>{title}</Heading>
       {value !== '' ? (
         <Paragraph>{value}</Paragraph>
       ) : (

--- a/src/app/[locale]/incident/summary/page.tsx
+++ b/src/app/[locale]/incident/summary/page.tsx
@@ -1,14 +1,20 @@
 import { NextIntlClientProvider, useMessages, useTranslations } from 'next-intl'
 import { IncidentSummaryForm } from '@/app/[locale]/incident/summary/components/IncidentSummaryForm'
-import { Heading } from '@/components/index'
+import { HeadingGroup, Heading, PreHeading } from '@/components/index'
 
 export default function SummaryDetailsPage() {
   const t = useTranslations('describe-summary')
+  const tGeneral = useTranslations('general.describe_form')
   const messages = useMessages()
 
   return (
     <div className="flex flex-col gap-4">
-      <Heading level={1}>{t('heading')}</Heading>
+      <HeadingGroup>
+        <Heading level={1}>{t('heading')}</Heading>
+        <PreHeading>
+          {tGeneral('pre-heading', { current: 4, max: 4 })}
+        </PreHeading>
+      </HeadingGroup>
       <NextIntlClientProvider messages={messages}>
         <IncidentSummaryForm />
       </NextIntlClientProvider>

--- a/src/app/[locale]/incident/summary/page.tsx
+++ b/src/app/[locale]/incident/summary/page.tsx
@@ -1,6 +1,30 @@
 import { NextIntlClientProvider, useMessages, useTranslations } from 'next-intl'
 import { IncidentSummaryForm } from '@/app/[locale]/incident/summary/components/IncidentSummaryForm'
-import { HeadingGroup, Heading, PreHeading } from '@/components/index'
+import { Heading, HeadingGroup, PreHeading } from '@/components/index'
+import { getTranslations } from 'next-intl/server'
+import { createTitle } from '@/lib/utils/create-title'
+import { Metadata } from 'next/types'
+
+const currentStep = 4
+const maxStep = 4
+
+export async function generateMetadata(): Promise<Metadata> {
+  const errorMessage = ''
+  const t = await getTranslations('describe-summary')
+  const tGeneral = await getTranslations('general.describe_form')
+
+  return {
+    title: createTitle(
+      [
+        errorMessage ? tGeneral('title-prefix-error') : '',
+        tGeneral('pre-heading', { current: currentStep, max: maxStep }),
+        t('heading'),
+        'gemeente Voorbeeld',
+      ],
+      tGeneral('title-separator')
+    ),
+  }
+}
 
 export default function SummaryDetailsPage() {
   const t = useTranslations('describe-summary')
@@ -12,7 +36,7 @@ export default function SummaryDetailsPage() {
       <HeadingGroup>
         <Heading level={1}>{t('heading')}</Heading>
         <PreHeading>
-          {tGeneral('pre-heading', { current: 4, max: 4 })}
+          {tGeneral('pre-heading', { current: currentStep, max: maxStep })}
         </PreHeading>
       </HeadingGroup>
       <NextIntlClientProvider messages={messages}>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,7 +6,6 @@ import '@utrecht/design-tokens/dist/index.css'
 const inter = Inter({ subsets: ['latin'] })
 
 export const metadata: Metadata = {
-  title: 'Maak een melding',
   description: 'Maak een melding bij jouw gemeente.',
 }
 

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -4,6 +4,10 @@ import { Container } from '@/components/layout'
 export { Select, Container }
 
 export {
-  Paragraph,
+  Alert,
   Heading,
+  HeadingGroup,
+  Link,
+  Paragraph,
+  PreHeading,
 } from '@utrecht/component-library-react/dist/css-module'

--- a/src/lib/utils/create-title.ts
+++ b/src/lib/utils/create-title.ts
@@ -1,0 +1,6 @@
+export const createTitle = (
+  args: (string | undefined)[],
+  titleSeparator = ' · '
+): string => {
+  return args.filter((value) => value).join(titleSeparator)
+}

--- a/translations/en.json
+++ b/translations/en.json
@@ -89,6 +89,7 @@
   },
   "general": {
     "describe_form": {
+      "pre-heading": "Step {current} of {max}",
       "back_button": "Back",
       "next_button": "Next",
       "submit_button": "Submit"

--- a/translations/en.json
+++ b/translations/en.json
@@ -10,7 +10,7 @@
     "new_notification": "New notification"
   },
   "describe-report": {
-    "heading": "1. Describe your report",
+    "heading": "Describe your report",
     "form": {
       "describe_textarea_heading": "What is it about?",
       "describe_textarea_description": "Do not type personal information in this description. We will ask this of you later in this form.",
@@ -26,7 +26,7 @@
     }
   },
   "describe-add": {
-    "heading": "2. Location and questions",
+    "heading": "Location and questions",
     "form": {
       "add_map_heading": "Where is it?",
       "add_choose_location_button": "Choose location",
@@ -39,7 +39,7 @@
     }
   },
   "describe-contact": {
-    "heading": "3. Contact details",
+    "heading": "Contact details",
     "form": {
       "heading": "May we call you for questions? And keep you informed via e-mail?",
       "description": "Often we have another question. With this we can solve the problem faster or better. Or we want to explain something. We would then like to give you a call. Or else we e-mail you.\n\nWe only use your phone number and e-mail address for this report.",
@@ -55,7 +55,7 @@
     }
   },
   "describe-summary": {
-    "heading": "4. Submit",
+    "heading": "Submit",
     "description": "Check your information and submit your report.",
     "steps": {
       "step_one": {
@@ -89,6 +89,8 @@
   },
   "general": {
     "describe_form": {
+      "title-separator": " · ",
+      "title-prefix-error": "Something went wrong!",
       "pre-heading": "Step {current} of {max}",
       "back_button": "Back",
       "next_button": "Next",

--- a/translations/nl.json
+++ b/translations/nl.json
@@ -22,7 +22,6 @@
         "file_size_too_large": "Bestandsgrootte is te groot. Elk bestand moet kleiner zijn dan 20MB.",
         "file_size_too_small": "Bestandsgrootte is te klein. Elk bestand moet minimaal 30KB zijn.",
         "file_limit_exceeded": "U kunt maximaal 3 bestanden uploaden."
-
       }
     }
   },
@@ -90,6 +89,7 @@
   },
   "general": {
     "describe_form": {
+      "pre-heading": "Stap {current} van {max}",
       "back_button": "Vorige",
       "next_button": "Volgende",
       "submit_button": "Verstuur"

--- a/translations/nl.json
+++ b/translations/nl.json
@@ -10,7 +10,7 @@
     "new_notification": "Nieuwe melding"
   },
   "describe-report": {
-    "heading": "1. Beschrijf uw melding",
+    "heading": "Beschrijf uw melding",
     "form": {
       "describe_textarea_heading": "Waar gaat het om?",
       "describe_textarea_description": "Typ geen persoonsgegevens in deze omschrijving. We vragen dit later in dit formulier aan u.",
@@ -26,7 +26,7 @@
     }
   },
   "describe-add": {
-    "heading": "2. Locatie en vragen",
+    "heading": "Locatie en vragen",
     "form": {
       "add_map_heading": "Waar is het?",
       "add_choose_location_button": "Kies locatie",
@@ -39,7 +39,7 @@
     }
   },
   "describe-contact": {
-    "heading": "3. Contactgegevens",
+    "heading": "Contactgegevens",
     "form": {
       "heading": "Mogen we u bellen voor vragen? En op de hoogte houden via e-mail?",
       "description": "Vaak hebben we nog een vraag. Daarmee kunnen we het probleem sneller of beter oplossen. Of we willen iets uitleggen. Wij willen u dan graag even bellen. Of anders e-mailen wij u.\n\nWij gebruiken uw telefoonnummer en e-mailadres alléén voor deze melding.",
@@ -55,7 +55,7 @@
     }
   },
   "describe-summary": {
-    "heading": "4. Versturen",
+    "heading": "Versturen",
     "description": "Controleer uw gegevens en verstuur uw melding.",
     "steps": {
       "step_one": {
@@ -89,6 +89,8 @@
   },
   "general": {
     "describe_form": {
+      "title-separator": " · ",
+      "title-prefix-error": "Er ging iets fout!",
       "pre-heading": "Stap {current} van {max}",
       "back_button": "Vorige",
       "next_button": "Volgende",


### PR DESCRIPTION
**In deze PR**

* stap 4 (summary) Heading order aanpassen i.v.m. accessibility

Issue #54 

- `<HeadingGroup>` en `<PreHeading>` toevoegen aan `index.ts` 
- `<HeadingGroup>` en `<PreHeading>` toevoegen in iedere stap van form 
- translation toevoegen op iedere stap van form 
- `en.json` en `nl.json` updaten (`pre-heading": "Step {current} of {max}"`) 

Issue #55

- Functie generate Metadata: naam van stap, naam van form en gemeente in title 
- `en.json` en `nl.json` updaten (`title-separator`, `title-prefix-error`)