### PR TITLE
Apply Purmerend font-family to NextLinkWrapper (Stap 4 - Summary)

### DIFF
--- a/src/app/[locale]/incident/summary/components/IncidentSummaryForm.tsx
+++ b/src/app/[locale]/incident/summary/components/IncidentSummaryForm.tsx
@@ -112,7 +112,10 @@ const IncidentSummaryForm = () => {
       <div className="flex flex-col gap-4">
         <div className="flex flex-col gap-1 md:flex-row justify-between">
           <Heading level={2}>{t('steps.step_one.title')}</Heading>
-          <NextLinkWrapper href={stepToPath[FormStep.STEP_1_DESCRIPTION]}>
+          <NextLinkWrapper
+            className="signalen-summary-link"
+            href={stepToPath[FormStep.STEP_1_DESCRIPTION]}
+          >
             {t('steps.step_one.edit')}
           </NextLinkWrapper>
         </div>
@@ -131,7 +134,10 @@ const IncidentSummaryForm = () => {
       <div className="flex flex-col gap-4">
         <div className="flex flex-col gap-1 md:flex-row justify-between">
           <Heading level={2}>{t('steps.step_two.title')}</Heading>
-          <NextLinkWrapper href={stepToPath[FormStep.STEP_2_ADD]}>
+          <NextLinkWrapper
+            className="signalen-summary-link"
+            href={stepToPath[FormStep.STEP_2_ADD]}
+          >
             {t('steps.step_two.edit')}
           </NextLinkWrapper>
         </div>
@@ -172,7 +178,10 @@ const IncidentSummaryForm = () => {
       <div className="flex flex-col gap-4">
         <div className="flex flex-col gap-1 md:flex-row justify-between">
           <Heading level={2}>{t('steps.step_three.title')}</Heading>
-          <NextLinkWrapper href={stepToPath[FormStep.STEP_3_CONTACT]}>
+          <NextLinkWrapper
+            className="signalen-summary-link"
+            href={stepToPath[FormStep.STEP_3_CONTACT]}
+          >
             {t('steps.step_three.edit')}
           </NextLinkWrapper>
         </div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -148,3 +148,8 @@
 .signalen-loading-icon {
   --utrecht-icon-size: var(--basis-size-icon-4xl, 4em);
 }
+
+/* summary */
+.signalen-summary-link {
+  font-family: var(--utrecht-paragraph-font-family);
+}


### PR DESCRIPTION
**In deze PR**:

* classname op NextLinkWrapper
* styling in globals.css


| Before    | After |
| -------- | ------- |
| <img width="413" alt="Scherm­afbeelding 2024-11-26 om 11 05 19" src="https://github.com/user-attachments/assets/96ab72f5-13b1-49ec-8756-2a94d883315b">  | <img width="414" alt="Scherm­afbeelding 2024-11-26 om 11 05 54" src="https://github.com/user-attachments/assets/fac78873-2fff-4cfd-89d6-f6ac68a25e50">   |

