### PR TITLE
a11y: correct alt text for municipality logo in config, removed main …

### DIFF
--- a/config.json
+++ b/config.json
@@ -5,11 +5,11 @@
     "assets_url": "https://meldingen.demo.meierijstad.delta10.cloud",
     "supportedLanguages": [
       {
-        "label": "This page in English",
+        "label": "Switch to English",
         "lang": "en"
       },
       {
-        "label": "Deze pagina in het Nederlands",
+        "label": "Schakel over naar het Nederlands",
         "lang": "nl"
       }
     ],

--- a/config.json
+++ b/config.json
@@ -16,7 +16,7 @@
     "naam": "gemeente Purmerend",
     "header": {
       "logo": {
-        "alt": "Logo: kop van een koe met onder elkaar de 3 delen van het woord Purmerend: 'pur', 'mer' en 'end'.",
+        "alt": "Gemeente Purmerend logo, naar de homepagina",
         "url": "purmerend-logo.svg",
         "caption": "Purmerend"
       }
@@ -53,16 +53,14 @@
       "nl": {
         "describe_report": {
           "alert": {
-            "help_text": "Lukt het niet om een melding te doen? Bel",
-            "opening_hours": "Wij zijn bereikbaar van maandag tot en met vrijdag van 08:00 tot 18:00 uur."
+            "help_text": "Problemen met het indienen van een melding? Bel [0299452452](tel:+0299452452) of mail naar [meldingen@purmerend.nl](mailto:meldingen@purmerend.nl). Wij zijn bereikbaar van maandag tot en met vrijdag van 8:00 uur tot 18:00 uur."
           }
         }
       },
       "en": {
         "describe_report": {
           "alert": {
-            "help_text": "Having trouble submitting a report? Call",
-            "opening_hours": "We are available Monday through Friday from 8:00 AM to 6:00 PM."
+            "help_text": "Having trouble submitting a report? Call [0299452452](tel:+0299452452) or mail [meldingen@purmerend.nl](mailto:meldingen@purmerend.nl). We are available monday through friday from 8:00 AM to 6:00 PM."
           }
         }
       }

--- a/config.md
+++ b/config.md
@@ -1,0 +1,9 @@
+To successfully configure the ```config.json``` file and ensure the Signalen frontend remains fully accessible, consider the following points:
+
+- ```base -> header -> logo -> "alt"```: Follow the guidance provided at https://nldesignsystem.nl/wcag/2.4.4/#fout-verkeerde-linktekst-voor-een-link-met-een-afbeelding regarding appropriate link text for image-based links.
+- ```base -> i18n -> en / nl -> describe_report -> alert -> "help_text"```:
+  This is a markdown field where you can include text and links. It is displayed on the first step of the page and is intended to inform users that they can also call or email regarding a notification. Example:
+
+    ```markdown
+    "help_text": Problemen met het indienen van een melding? Bel [0299452452](tel:+0299452452) of mail naar [meldingen@purmerend.nl](mailto:meldingen@purmerend.nl). Wij zijn bereikbaar van maandag tot en met vrijdag van 8:00 uur tot 18:00 uur.
+    ```

--- a/src/app/[locale]/components/Footer.tsx
+++ b/src/app/[locale]/components/Footer.tsx
@@ -4,7 +4,7 @@ import { IconChevronRight } from '@tabler/icons-react'
 import { useEffect, useState } from 'react'
 import { useConfig } from '@/hooks/useConfig'
 import { useTranslations } from 'next-intl'
-import { Link, PageFooter } from '@/components'
+import { Icon, Link, PageFooter } from '@/components'
 
 type footerLink = {
   href: string
@@ -49,7 +49,10 @@ const Footer = () => {
               href={link.href}
               className="flex items-center !no-underline hover:!underline"
             >
-              <IconChevronRight className="w-6 h-6" /> {link.label}
+              <Icon className="!w-6 !h-6">
+                <IconChevronRight />
+              </Icon>
+              {link.label}
             </Link>
           </li>
         ))}

--- a/src/app/[locale]/components/Footer.tsx
+++ b/src/app/[locale]/components/Footer.tsx
@@ -42,15 +42,18 @@ const Footer = () => {
 
   return (
     <PageFooter>
-      {links.map((link) => (
-        <Link
-          href={link.href}
-          key={link.label}
-          className="flex items-center !no-underline hover:!underline"
-        >
-          <IconChevronRight className="w-6 h-6" /> {link.label}
-        </Link>
-      ))}
+      <ul>
+        {links.map((link) => (
+          <li key={link.label}>
+            <Link
+              href={link.href}
+              className="flex items-center !no-underline hover:!underline"
+            >
+              <IconChevronRight className="w-6 h-6" /> {link.label}
+            </Link>
+          </li>
+        ))}
+      </ul>
     </PageFooter>
   )
 }

--- a/src/app/[locale]/incident/add/components/IncidentQuestionsLocationForm.tsx
+++ b/src/app/[locale]/incident/add/components/IncidentQuestionsLocationForm.tsx
@@ -7,7 +7,7 @@ import { useFormStore } from '@/store/form_store'
 import { IncidentFormFooter } from '@/app/[locale]/incident/components/IncidentFormFooter'
 import { usePathname, useRouter } from '@/routing/navigation'
 import { PublicQuestion } from '@/types/form'
-import { Alert } from '@/components/index'
+import { Alert, Paragraph } from '@/components/index'
 import { RenderSingleField } from '@/app/[locale]/incident/add/components/questions/RenderSingleField'
 import { LocationSelect } from '@/app/[locale]/incident/add/components/questions/LocationSelect'
 import { useTranslations } from 'next-intl'
@@ -151,7 +151,9 @@ export const IncidentQuestionsLocationForm = () => {
       >
         {methods.formState.errors.submit && (
           <Alert type="error">
-            {methods.formState.errors.submit.message?.toString()}
+            <Paragraph>
+              {methods.formState.errors.submit.message?.toString()}
+            </Paragraph>
           </Alert>
         )}
         {additionalQuestions.length ? (

--- a/src/app/[locale]/incident/add/components/MapDialog.tsx
+++ b/src/app/[locale]/incident/add/components/MapDialog.tsx
@@ -361,7 +361,9 @@ const MapDialog = ({
                 dialogMap &&
                 config &&
                 dialogMap.getZoom() < config.base.map.minimal_zoom && (
-                  <Alert type="error">{t('zoom_for_object')}</Alert>
+                  <Alert type="error">
+                    <Paragraph>{t('zoom_for_object')}</Paragraph>
+                  </Alert>
                 )}
               {field && dialogMap && config && (
                 <ul className="flex-1 overflow-y-auto">

--- a/src/app/[locale]/incident/add/components/questions/PlainText.tsx
+++ b/src/app/[locale]/incident/add/components/questions/PlainText.tsx
@@ -1,13 +1,13 @@
 import { QuestionField } from '@/types/form'
-import Markdown from 'react-markdown'
 import { Alert } from '@/components'
+import { RenderMarkdown } from '@/components/ui/RenderMarkdown'
 
 interface PlainTextProps extends QuestionField {}
 
 export const PlainText = ({ field }: PlainTextProps) => {
   return field.meta.value ? (
     <Alert type="error" data-testid="plain-text-hard-stop">
-      <Markdown>{field.meta.value}</Markdown>
+      <RenderMarkdown text={field.meta.value} />
     </Alert>
   ) : null
 }

--- a/src/app/[locale]/incident/components/IncidentDescriptionForm.tsx
+++ b/src/app/[locale]/incident/components/IncidentDescriptionForm.tsx
@@ -41,7 +41,7 @@ export const IncidentDescriptionForm = () => {
   }, [router])
 
   const incidentDescriptionFormSchema = z.object({
-    description: z.string().trim().min(1, tGeneral('errors.required')),
+    description: z.string().trim().min(1, t('errors.textarea_required')),
     files: z
       .array(z.instanceof(File))
       .refine(

--- a/src/app/[locale]/incident/components/IncidentDescriptionForm.tsx
+++ b/src/app/[locale]/incident/components/IncidentDescriptionForm.tsx
@@ -140,18 +140,19 @@ export const IncidentDescriptionForm = () => {
       />
 
       <Fieldset invalid={Boolean(form.formState.errors.files?.message)}>
-        <FieldsetLegend>{`${t('describe_textarea_heading')} (${tGeneral('form.not_required_short')})`}</FieldsetLegend>
+        <FieldsetLegend>
+          {`${t('describe_textarea_heading')} (${tGeneral('form.not_required_short')})`}
+          <FormFieldDescription>
+            {t('describe_upload_description')}
+          </FormFieldDescription>
 
-        <FormFieldDescription>
-          {t('describe_upload_description')}
-        </FormFieldDescription>
-
-        {Boolean(form.formState.errors.files?.message) &&
-          form.formState.errors.files?.message && (
-            <FormFieldErrorMessage>
-              {form.formState.errors.files?.message}
-            </FormFieldErrorMessage>
-          )}
+          {Boolean(form.formState.errors.files?.message) &&
+            form.formState.errors.files?.message && (
+              <FormFieldErrorMessage>
+                {form.formState.errors.files?.message}
+              </FormFieldErrorMessage>
+            )}
+        </FieldsetLegend>
 
         {/* @ts-ignore */}
         <FileUpload

--- a/src/app/[locale]/incident/components/IncidentDescriptionPage.tsx
+++ b/src/app/[locale]/incident/components/IncidentDescriptionPage.tsx
@@ -7,9 +7,24 @@ import { Alert, Link } from '@/components'
 import { IncidentDescriptionForm } from '@/app/[locale]/incident/components/IncidentDescriptionForm'
 import FormProgress from '@/app/[locale]/components/FormProgress'
 import { useConfig } from '@/hooks/useConfig'
+import Markdown, { defaultUrlTransform } from 'react-markdown'
 
 const currentStep = 1
 const maxStep = 4
+
+const LinkRenderer: React.FC<{ href: string; children: React.ReactNode }> = ({
+  href,
+  children,
+}) => {
+  if (href.startsWith('tel:')) {
+    return <a href={href}>{children}</a>
+  }
+  return (
+    <a href={href} target="_blank" rel="noopener noreferrer">
+      {children}
+    </a>
+  )
+}
 
 export const IncidentDescriptionPage = () => {
   const t = useTranslations('describe_report')
@@ -34,13 +49,17 @@ export const IncidentDescriptionPage = () => {
           </FormProgress>
           {config ? (
             <Alert>
-              <Paragraph>
-                {`${t('alert.help_text')} `}
-                <Link href={`tel:${config.base.contact.tel}`}>
-                  {config.base.contact.tel}
-                </Link>
-              </Paragraph>
-              <Paragraph>{t('alert.opening_hours')}</Paragraph>
+              <Markdown
+                urlTransform={(url) =>
+                  url.startsWith('tel:') ? url : defaultUrlTransform(url)
+                }
+                components={{
+                  p: (props) => <Paragraph>{props.children}</Paragraph>,
+                  a: (props) => <Link {...props}>{props.children}</Link>,
+                }}
+              >
+                {t('alert.help_text')}
+              </Markdown>
             </Alert>
           ) : null}
           <IncidentDescriptionForm />

--- a/src/app/[locale]/incident/components/IncidentDescriptionPage.tsx
+++ b/src/app/[locale]/incident/components/IncidentDescriptionPage.tsx
@@ -12,20 +12,6 @@ import Markdown, { defaultUrlTransform } from 'react-markdown'
 const currentStep = 1
 const maxStep = 4
 
-const LinkRenderer: React.FC<{ href: string; children: React.ReactNode }> = ({
-  href,
-  children,
-}) => {
-  if (href.startsWith('tel:')) {
-    return <a href={href}>{children}</a>
-  }
-  return (
-    <a href={href} target="_blank" rel="noopener noreferrer">
-      {children}
-    </a>
-  )
-}
-
 export const IncidentDescriptionPage = () => {
   const t = useTranslations('describe_report')
   const { loaded } = useFormStore()

--- a/src/app/[locale]/incident/components/IncidentDescriptionPage.tsx
+++ b/src/app/[locale]/incident/components/IncidentDescriptionPage.tsx
@@ -2,12 +2,12 @@
 
 import { useTranslations } from 'next-intl'
 import { useFormStore } from '@/store/form_store'
-import { Heading, Paragraph, HeadingGroup, PreHeading } from '@/components'
-import { Alert, Link } from '@/components'
+import { Heading, HeadingGroup, PreHeading } from '@/components'
+import { Alert } from '@/components'
 import { IncidentDescriptionForm } from '@/app/[locale]/incident/components/IncidentDescriptionForm'
 import FormProgress from '@/app/[locale]/components/FormProgress'
 import { useConfig } from '@/hooks/useConfig'
-import Markdown, { defaultUrlTransform } from 'react-markdown'
+import { RenderMarkdown } from '@/components/ui/RenderMarkdown'
 
 const currentStep = 1
 const maxStep = 4
@@ -35,17 +35,7 @@ export const IncidentDescriptionPage = () => {
           </FormProgress>
           {config ? (
             <Alert>
-              <Markdown
-                urlTransform={(url) =>
-                  url.startsWith('tel:') ? url : defaultUrlTransform(url)
-                }
-                components={{
-                  p: (props) => <Paragraph>{props.children}</Paragraph>,
-                  a: (props) => <Link {...props}>{props.children}</Link>,
-                }}
-              >
-                {t('alert.help_text')}
-              </Markdown>
+              <RenderMarkdown text={t('alert.help_text')} />
             </Alert>
           ) : null}
           <IncidentDescriptionForm />

--- a/src/app/[locale]/incident/layout.tsx
+++ b/src/app/[locale]/incident/layout.tsx
@@ -5,10 +5,8 @@ export default function IncidentLayout({ children }: Layout) {
   const messages = useMessages()
 
   return (
-    <main>
-      <NextIntlClientProvider messages={messages}>
-        <div className="col-span-1 md:col-span-8">{children}</div>
-      </NextIntlClientProvider>
-    </main>
+    <NextIntlClientProvider messages={messages}>
+      <div className="col-span-1 md:col-span-8">{children}</div>
+    </NextIntlClientProvider>
   )
 }

--- a/src/components/ui/RenderMarkdown.tsx
+++ b/src/components/ui/RenderMarkdown.tsx
@@ -1,0 +1,18 @@
+import Markdown, { defaultUrlTransform } from 'react-markdown'
+import { Link, Paragraph } from '@/components'
+
+export const RenderMarkdown = ({ text }: { text: string }) => {
+  return (
+    <Markdown
+      urlTransform={(url) =>
+        url.startsWith('tel:') ? url : defaultUrlTransform(url)
+      }
+      components={{
+        p: (props) => <Paragraph>{props.children}</Paragraph>,
+        a: (props) => <Link {...props}>{props.children}</Link>,
+      }}
+    >
+      {text}
+    </Markdown>
+  )
+}

--- a/src/components/ui/upload/FileUpload.tsx
+++ b/src/components/ui/upload/FileUpload.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react'
 import { IconCirclePlus } from '@tabler/icons-react'
 import PreviewFile from '@/components/ui/upload/PreviewFile'
 import { useTranslations } from 'next-intl'
+import { Icon } from '@/components'
 
 export const ACCEPTED_IMAGE_TYPES = [
   'image/jpeg',
@@ -62,11 +63,13 @@ export const FileUpload = React.forwardRef<HTMLLabelElement, FileUploadProps>(
               onKeyDown={(e) => handleKeyDown(e)}
             >
               <span className="flex justify-center items-center h-full relative">
-                <IconCirclePlus
+                <Icon
                   className={`transition-all duration-300 ${
-                    labelHovered ? 'w-16 h-16' : 'w-14 h-14'
+                    labelHovered ? '!w-16 !h-16' : '!w-14 !h-14'
                   }`}
-                />
+                >
+                  <IconCirclePlus />
+                </Icon>
               </span>
             </label>
             <input

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -40,7 +40,6 @@ export type AppConfig = {
         describe_report: {
           alert: {
             help_text: string
-            opening_hours: string
           }
         }
       }

--- a/translations/en.json
+++ b/translations/en.json
@@ -10,6 +10,7 @@
       "describe_upload_heading": "Add photos",
       "describe_upload_description": "Add a photo to clarify the situation (maximum of 5 photos).",
       "errors": {
+        "textarea_required": "Input error: enter what the notification is about",
         "file_type_invalid": "Invalid file type. Only JPEG, PNG, and GIF are accepted.",
         "file_size_too_large": "File size too large. Each file must be less than 20MB.",
         "file_size_too_small": "File size too small. Each file must be at least 30KB."

--- a/translations/en.json
+++ b/translations/en.json
@@ -11,9 +11,9 @@
       "describe_upload_description": "Add a photo to clarify the situation (maximum of 5 photos).",
       "errors": {
         "textarea_required": "Input error: enter what the notification is about",
-        "file_type_invalid": "Invalid file type. Only JPEG, PNG, and GIF are accepted.",
-        "file_size_too_large": "File size too large. Each file must be less than 20MB.",
-        "file_size_too_small": "File size too small. Each file must be at least 30KB."
+        "file_type_invalid": "Input error: invalid file type. Only JPEG, PNG, and GIF are accepted.",
+        "file_size_too_large": "Input error: file size too large. Each file must be less than 20MB.",
+        "file_size_too_small": "Input error: file size too small. Each file must be at least 30KB."
       }
     },
     "alert": {

--- a/translations/en.json
+++ b/translations/en.json
@@ -16,8 +16,7 @@
       }
     },
     "alert": {
-      "help_text": "Having trouble submitting a report? Call: ",
-      "opening_hours": "We are available Monday through Friday from 8:00 AM to 6:00 PM."
+      "help_text": "Having trouble submitting a report? Call: "
     }
   },
   "describe_add": {

--- a/translations/en.json
+++ b/translations/en.json
@@ -6,7 +6,7 @@
     "heading": "Describe your report",
     "form": {
       "describe_textarea_heading": "What is it about?",
-      "describe_textarea_description": "Do not type personal information in this description. We will ask this of you later in this form.",
+      "describe_textarea_description": "Enter the content of your report here. You can only submit one report at a time. Do not include personal information in this description; this will be requested later in the form.",
       "describe_upload_heading": "Add photos",
       "describe_upload_description": "Add a photo to clarify the situation (maximum of 5 photos).",
       "errors": {

--- a/translations/nl.json
+++ b/translations/nl.json
@@ -11,9 +11,9 @@
       "describe_upload_description": "Voeg een foto toe om de situatie te verduidelijken (maximaal 5 foto's).",
       "errors": {
         "textarea_required": "Invoerfout: vul in waar de melding over gaat",
-        "file_type_invalid": "Ongeldig bestandstype. Alleen JPEG, PNG, en GIF zijn toegestaan.",
-        "file_size_too_large": "Bestandsgrootte is te groot. Elk bestand moet kleiner zijn dan 20MB.",
-        "file_size_too_small": "Bestandsgrootte is te klein. Elk bestand moet minimaal 30KB zijn."
+        "file_type_invalid": "Invoerfout: ongeldig bestandstype. Alleen JPEG, PNG, en GIF zijn toegestaan.",
+        "file_size_too_large": "Invoerfout: bestandsgrootte is te groot. Elk bestand moet kleiner zijn dan 20MB.",
+        "file_size_too_small": "Invoerfout: bestandsgrootte is te klein. Elk bestand moet minimaal 30KB zijn."
       }
     },
     "alert": {

--- a/translations/nl.json
+++ b/translations/nl.json
@@ -6,7 +6,7 @@
     "heading": "Beschrijf uw melding",
     "form": {
       "describe_textarea_heading": "Waar gaat het om?",
-      "describe_textarea_description": "Typ geen persoonsgegevens in deze omschrijving. We vragen dit later in dit formulier aan u.",
+      "describe_textarea_description": "Typ hier de inhoud van uw melding. U kunt slechts één melding tegelijk indienen. Vermeld geen persoonlijke gegevens in deze beschrijving; hier wordt later in het formulier naar gevraagd.",
       "describe_upload_heading": "Foto's toevoegen",
       "describe_upload_description": "Voeg een foto toe om de situatie te verduidelijken (maximaal 5 foto's).",
       "errors": {

--- a/translations/nl.json
+++ b/translations/nl.json
@@ -10,6 +10,7 @@
       "describe_upload_heading": "Foto's toevoegen",
       "describe_upload_description": "Voeg een foto toe om de situatie te verduidelijken (maximaal 5 foto's).",
       "errors": {
+        "textarea_required": "Invoerfout: vul in waar de melding over gaat",
         "file_type_invalid": "Ongeldig bestandstype. Alleen JPEG, PNG, en GIF zijn toegestaan.",
         "file_size_too_large": "Bestandsgrootte is te groot. Elk bestand moet kleiner zijn dan 20MB.",
         "file_size_too_small": "Bestandsgrootte is te klein. Elk bestand moet minimaal 30KB zijn."

--- a/translations/nl.json
+++ b/translations/nl.json
@@ -16,8 +16,7 @@
       }
     },
     "alert": {
-      "help_text": "Lukt het niet om een melding te doen? Bel",
-      "opening_hours": "Wij zijn bereikbaar van maandag tot en met vrijdag van 08:00 tot 18:00 uur."
+      "help_text": "Lukt het niet om een melding te doen? Bel"
     }
   },
   "describe_add": {


### PR DESCRIPTION
Fixes things mentioned in issue #185 

- Correct alt text for municipality logo in config, and docs related to this ```config.json``` field in ```config.md```
- Removed <main> element inside of <article> element
- Correct text with telephone and e-mail links for alert in step one, and docs related to this ```config.json``` field in ```config.md``` 
- Hiding icon in FileUpload for screenreaders (decorative image)
- Clearer error message for description textarea in step one
- Put footer links in an ```<ul>``` wrapper and each link itself in a ```<li>``` element
- Clearer description for textarea step one
- Clearer aria-labels for items in language switch
- Read out description and error for upload form
- Use correct html elements in <Alert> components