### PR TITLE
a11y: remove default html blur error from email field in step three

### DIFF
--- a/src/app/[locale]/incident/contact/components/IncidentContactForm.tsx
+++ b/src/app/[locale]/incident/contact/components/IncidentContactForm.tsx
@@ -115,7 +115,10 @@ const IncidentContactForm = () => {
         />
         <Fieldset aria-describedby="todo-id">
           <FieldsetLegend>
-            <Heading level={2}>{t('send_to_other_instance_heading')}</Heading>
+            <Heading level={2}>
+              {t('send_to_other_instance_heading')} (
+              {tGeneral('form.not_required_short')})
+            </Heading>
           </FieldsetLegend>
           <div className="flex flex-col">
             <FormFieldDescription id="todo-id">

--- a/src/app/[locale]/incident/contact/components/IncidentContactForm.tsx
+++ b/src/app/[locale]/incident/contact/components/IncidentContactForm.tsx
@@ -91,7 +91,7 @@ const IncidentContactForm = () => {
 
   return (
     <div>
-      <Alert>
+      <Alert className="sr-only">
         <Paragraph>{`${t('alert_no_required_fields')} `}</Paragraph>
       </Alert>
       <div className="mt-8">

--- a/src/app/[locale]/incident/contact/components/IncidentContactForm.tsx
+++ b/src/app/[locale]/incident/contact/components/IncidentContactForm.tsx
@@ -96,7 +96,7 @@ const IncidentContactForm = () => {
       </Alert>
       <div className="mt-8">
         <Heading level={2}>{t('heading')}</Heading>
-        <Paragraph>{t('description')}</Paragraph>
+        <Paragraph className="contact-paragraph">{t('description')}</Paragraph>
       </div>
       <form
         onSubmit={form.handleSubmit(onSubmit)}
@@ -124,11 +124,11 @@ const IncidentContactForm = () => {
               {t('send_to_other_instance_heading')} (
               {tGeneral('form.not_required_short')})
             </Heading>
+            <FormFieldDescription id="todo-id">
+              {t('send_to_other_instance_description')}
+            </FormFieldDescription>
           </FieldsetLegend>
           <div className="flex flex-col">
-            <FormFieldDescription id="todo-id">
-              <Paragraph>{t('send_to_other_instance_description')}</Paragraph>
-            </FormFieldDescription>
             <div className="w-full">
               <FormFieldCheckbox
                 label={t('describe_checkbox_input_description', {

--- a/src/app/[locale]/incident/contact/components/IncidentContactForm.tsx
+++ b/src/app/[locale]/incident/contact/components/IncidentContactForm.tsx
@@ -10,12 +10,14 @@ import validator from 'validator'
 import { useFormStore } from '@/store/form_store'
 import { useEffect } from 'react'
 import {
+  Alert,
   Fieldset,
   FieldsetLegend,
   FormFieldCheckbox,
   FormFieldDescription,
   FormFieldTextbox,
   Heading,
+  Link,
   Paragraph,
 } from '@/components/index'
 import { getCurrentStep, getNextStepPath } from '@/lib/utils/stepper'
@@ -89,7 +91,10 @@ const IncidentContactForm = () => {
 
   return (
     <div>
-      <div>
+      <Alert>
+        <Paragraph>{`${t('alert_no_required_fields')} `}</Paragraph>
+      </Alert>
+      <div className="mt-8">
         <Heading level={2}>{t('heading')}</Heading>
         <Paragraph>{t('description')}</Paragraph>
       </div>

--- a/src/app/[locale]/incident/contact/components/IncidentContactForm.tsx
+++ b/src/app/[locale]/incident/contact/components/IncidentContactForm.tsx
@@ -99,7 +99,7 @@ const IncidentContactForm = () => {
       >
         <FormFieldTextbox
           label={`${t('describe_phone_input_heading')} (${tGeneral('form.not_required_short')})`}
-          autoComplete="phone"
+          autoComplete="tel"
           errorMessage={form.formState.errors.phone?.message}
           invalid={Boolean(form.formState.errors.phone?.message)}
           required={false}
@@ -107,7 +107,6 @@ const IncidentContactForm = () => {
         />
         <FormFieldTextbox
           label={`${t('describe_mail_input_heading')} (${tGeneral('form.not_required_short')})`}
-          type="email"
           autoComplete="email"
           errorMessage={form.formState.errors.email?.message}
           invalid={Boolean(form.formState.errors.email?.message)}

--- a/src/app/[locale]/incident/summary/components/IncidentSummaryForm.tsx
+++ b/src/app/[locale]/incident/summary/components/IncidentSummaryForm.tsx
@@ -119,101 +119,123 @@ const IncidentSummaryForm = () => {
   return (
     <div className="flex flex-col gap-8">
       <Paragraph appearance="lead">{t('description')}</Paragraph>
+
       <Divider />
-      <div className="flex flex-col gap-4">
-        <div className="flex flex-col gap-1 md:flex-row justify-between">
+
+      <div className="summary-grid">
+        <div className="summary-grid__heading">
           <Heading level={2}>1. {tStepReport('heading')}</Heading>
+        </div>
+        <div className="summary-grid__main">
+          <IncidentSummaryFormItem
+            title={tStepReport('form.describe_textarea_heading')}
+            value={formState.description}
+          />
+          {files.length > 0 && (
+            <IncidentSummaryFormAttachments
+              title={tStepReport('form.describe_upload_heading')}
+              attachments={files}
+            />
+          )}
+        </div>
+        <div className="summary-grid__link">
           <NextLinkWrapper href={stepToPath[FormStep.STEP_1_DESCRIPTION]}>
             {t('edit_step_report')}
           </NextLinkWrapper>
         </div>
-        <IncidentSummaryFormItem
-          title={tStepReport('form.describe_textarea_heading')}
-          value={formState.description}
-        />
-        {files.length > 0 && (
-          <IncidentSummaryFormAttachments
-            title={tStepReport('form.describe_upload_heading')}
-            attachments={files}
-          />
-        )}
       </div>
+
       <Divider />
-      <div className="flex flex-col gap-4">
-        <div className="flex flex-col gap-1 md:flex-row justify-between">
+
+      <div className="summary-grid">
+        <div className="sumary-grid__heading">
           <Heading level={2}>2. {tStepAdd('heading')}</Heading>
+        </div>
+
+        <div className="summary-grid__main flex flex-col gap-4">
+          <IncidentSummaryFormItem
+            title={tStepAdd('form.add_map_heading')}
+            value={formState.address?.weergave_naam}
+          >
+            <div style={{ minHeight: 200, height: 200 }}>
+              <LocationMap />
+            </div>
+          </IncidentSummaryFormItem>
+
+          {/* TODO: AssetSelect en LocationSelect hier tonen, indien een / beide zijn ingevuld */}
+          {formState.extra_properties.map((answer) => {
+            return (
+              <IncidentSummaryFormItem
+                title={answer.label}
+                key={answer.id}
+                value={
+                  typeof answer.answer === 'string'
+                    ? answer.answer
+                    : Array.isArray(answer.answer)
+                      ? answer.answer
+                          .filter(
+                            (singleAnswer) =>
+                              singleAnswer !== false && singleAnswer !== 'empty'
+                          )
+                          .map((singleAnswer) => singleAnswer.label)
+                          .join(', ')
+                      : answer.answer.label
+                }
+              />
+            )
+          })}
+        </div>
+
+        <div className="summary-grid__link">
           <NextLinkWrapper href={stepToPath[FormStep.STEP_2_ADD]}>
             {t('edit_step_add')}
           </NextLinkWrapper>
         </div>
-
-        <IncidentSummaryFormItem
-          title={tStepAdd('form.add_map_heading')}
-          value={formState.address?.weergave_naam}
-        >
-          <div style={{ minHeight: 200, height: 200 }}>
-            <LocationMap />
-          </div>
-        </IncidentSummaryFormItem>
-
-        {/* TODO: AssetSelect en LocationSelect hier tonen, indien een / beide zijn ingevuld */}
-        {formState.extra_properties.map((answer) => {
-          return (
-            <IncidentSummaryFormItem
-              title={answer.label}
-              key={answer.id}
-              value={
-                typeof answer.answer === 'string'
-                  ? answer.answer
-                  : Array.isArray(answer.answer)
-                    ? answer.answer
-                        .filter(
-                          (singleAnswer) =>
-                            singleAnswer !== false && singleAnswer !== 'empty'
-                        )
-                        .map((singleAnswer) => singleAnswer.label)
-                        .join(', ')
-                    : answer.answer.label
-              }
-            />
-          )
-        })}
       </div>
+
       <Divider />
-      <div className="flex flex-col gap-4">
-        <div className="flex flex-col gap-1 md:flex-row justify-between">
+
+      <div className="summary-grid">
+        <div className="summary-grid__heading">
           <Heading level={2}>{tStepContact('heading')}</Heading>
+        </div>
+        <div className="summary-grid__main flex flex-col gap-4">
+          {!formState.phone &&
+          !formState.email &&
+          !formState.sharing_allowed ? (
+            <Paragraph>{tStepContact('form.no_contact_details')}</Paragraph>
+          ) : (
+            <>
+              {formState.phone && (
+                <IncidentSummaryFormItem
+                  title={tStepContact('form.describe_phone_input_heading')}
+                  value={formState.phone}
+                />
+              )}
+              {formState.email && (
+                <IncidentSummaryFormItem
+                  title={tStepContact('form.describe_mail_input_heading')}
+                  value={formState.email}
+                />
+              )}
+              {formState.sharing_allowed && (
+                <IncidentSummaryFormItem
+                  title={tStepContact('form.sharing_heading_short')}
+                  value={tStepContact(
+                    'form.describe_checkbox_input_description',
+                    { organization: config?.base.municipality_display_name }
+                  )}
+                />
+              )}
+            </>
+          )}
+        </div>
+
+        <div className="summary-grid__link">
           <NextLinkWrapper href={stepToPath[FormStep.STEP_3_CONTACT]}>
             {t('edit_step_contact')}
           </NextLinkWrapper>
         </div>
-        {!formState.phone && !formState.email && !formState.sharing_allowed ? (
-          <Paragraph>{tStepContact('form.no_contact_details')}</Paragraph>
-        ) : (
-          <>
-            {formState.phone && (
-              <IncidentSummaryFormItem
-                title={tStepContact('form.describe_phone_input_heading')}
-                value={formState.phone}
-              />
-            )}
-            {formState.email && (
-              <IncidentSummaryFormItem
-                title={tStepContact('form.describe_mail_input_heading')}
-                value={formState.email}
-              />
-            )}
-            {formState.sharing_allowed && (
-              <IncidentSummaryFormItem
-                title={tStepContact('form.sharing_heading_short')}
-                value={tStepContact(
-                  'form.describe_checkbox_input_description',
-                  { organization: config?.base.municipality_display_name }
-                )}
-              />
-            )}
-          </>
-        )}
       </div>
 
       <SubmitAlert error={error} loading={loading} />

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -185,6 +185,16 @@
   gap: 1rem;
 }
 
+/* 640px is the "SM" breakpoint in tailwind */
+@media only screen and (max-width: 640px) {
+  .summary-grid {
+    grid-template-areas:
+    "summary-heading summary-heading"
+    "summary-body summary-body"
+    "summary-link summary-link"
+  }
+}
+
 .summary-grid__heading {
   grid-area: summary-heading;
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -170,6 +170,11 @@
     --utrecht-listbox-color: black;
 }
 
+/* contact page */
+.contact-paragraph {
+  color: var(--utrecht-form-field-description-color) !important;
+}
+
 /* summary page grid */
 .summary-grid {
   display: grid;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -169,3 +169,25 @@
     --utrecht-listbox-background-color: white;
     --utrecht-listbox-color: black;
 }
+
+/* summary page grid */
+.summary-grid {
+  display: grid;
+  grid-template-areas:
+    "summary-heading summary-link"
+    "summary-body summary-body";
+  grid-template-columns: 1fr auto;
+  gap: 1rem;
+}
+
+.summary-grid__heading {
+  grid-area: summary-heading;
+}
+
+.summary-grid__main {
+  grid-area: summary-body;
+}
+
+.summary-grid__link {
+  grid-area: summary-link;
+}

--- a/translations/en.json
+++ b/translations/en.json
@@ -54,6 +54,7 @@
   "describe_contact": {
     "heading": "Contact details",
     "form": {
+      "alert_no_required_fields": "This form consists of optional questions only.",
       "heading": "May we call you for questions? And keep you informed via e-mail?",
       "description": "Often we have another question. With this we can solve the problem faster or better. Or we want to explain something. We would then like to give you a call. Or else we e-mail you.\n\nWe only use your phone number and e-mail address for this report.",
       "send_to_other_instance_heading": "May we forward your report?",

--- a/translations/nl.json
+++ b/translations/nl.json
@@ -54,6 +54,7 @@
   "describe_contact": {
     "heading": "Contactgegevens",
     "form": {
+      "alert_no_required_fields": "Dit formulier bestaat enkel uit optionele vragen.",
       "heading": "Mogen we u bellen voor vragen? En op de hoogte houden via e-mail?",
       "description": "Vaak hebben we nog een vraag. Daarmee kunnen we het probleem sneller of beter oplossen. Of we willen iets uitleggen. Wij willen u dan graag even bellen. Of anders e-mailen wij u.\n\nWij gebruiken uw telefoonnummer en e-mailadres alléén voor deze melding.",
       "send_to_other_instance_heading": "Mogen we uw melding doorsturen?",


### PR DESCRIPTION
Fixes following things mentioned in draft issue "Stap 3, toegankelijkheid hangende issues" and "Stap 4, toegankelijkheid hangende issues":

**Step three**
- Remove default html blur error from email field in step three
- Keep use of (not required) consistent in step three
- Make clear that form consists of only optional questions in step three
- Use autoComplete="tel" instead of wrong autoComplete="phone"
- Clearer hierarchy in step three between descriptions and headings by color

**Step four**
- Change order of dom elements in summary items step four
