### PR TITLE
a11y: use clear language labels for language switch

### DIFF
--- a/config.json
+++ b/config.json
@@ -6,11 +6,13 @@
     "supportedLanguages": [
       {
         "label": "Switch to English",
-        "lang": "en"
+        "lang": "en",
+        "name": "English"
       },
       {
         "label": "Schakel over naar het Nederlands",
-        "lang": "nl"
+        "lang": "nl",
+        "name": "Nederlands"
       }
     ],
     "naam": "gemeente Purmerend",

--- a/src/app/[locale]/components/Header.tsx
+++ b/src/app/[locale]/components/Header.tsx
@@ -39,7 +39,7 @@ const Header = () => {
   return (
     <>
       <PageHeader>
-        <div className="flex flex-row items-center justify-between">
+        <div className="flex flex-col md:flex-row gap-4 md:items-center justify-between">
           {homepageHref ? (
             <Link
               boxContent

--- a/src/app/[locale]/components/LanguageSwitch.tsx
+++ b/src/app/[locale]/components/LanguageSwitch.tsx
@@ -19,9 +19,9 @@ const LanguageSwitch = () => {
 
   return (
     <div className="pr-4">
-      <ButtonGroup>
+      <ButtonGroup className="flex flex-col md:flex-row !gap-0 md:!gap-4">
         {config &&
-          config.base.supportedLanguages.map(({ label, lang }) => (
+          config.base.supportedLanguages.map(({ label, lang, name }) => (
             <LinkButton
               inline
               pressed={lang === locale}
@@ -31,7 +31,7 @@ const LanguageSwitch = () => {
               disabled={isPending || lang === locale}
               onClick={() => onLanguageChange(lang)}
             >
-              {lang.toUpperCase()}
+              {name}
             </LinkButton>
           ))}
       </ButtonGroup>

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -6,6 +6,7 @@ export type AppConfig = {
     supportedLanguages: Array<{
       label: string
       lang: string
+      name: string
     }>
     /**
      * One or more class names for the NL Design System theme.


### PR DESCRIPTION
Fixes #247 