### PR TITLE
a11y: consistent naming in english (notification -> report), fix titl…

### DIFF
--- a/src/app/[locale]/incident/thankyou/components/ThankyouContent.tsx
+++ b/src/app/[locale]/incident/thankyou/components/ThankyouContent.tsx
@@ -1,0 +1,39 @@
+'use client'
+
+import { useTranslations } from 'next-intl'
+import { useFormStore } from '@/store/form_store'
+import { stepToPath, useRouter } from '@/routing/navigation'
+import { FormStep } from '@/types/form'
+import { Heading, Paragraph, Button, PreserveData } from '@/components'
+import React from 'react'
+
+export const ThankyouContent = () => {
+  const t = useTranslations('describe_thankyou')
+  const { resetForm, formState } = useFormStore()
+  const router = useRouter()
+
+  const resetState = () => {
+    resetForm()
+    router.push(stepToPath[FormStep.STEP_1_DESCRIPTION])
+  }
+
+  return (
+    <div className="flex flex-col gap-8">
+      <Heading level={1}>{t('heading')}</Heading>
+      <div className="flex flex-col gap-2">
+        <Paragraph>
+          {t('description_notification_number')}
+          <PreserveData> {formState.sig_number}</PreserveData>
+        </Paragraph>
+        <Paragraph>{t('description_notification_email')}</Paragraph>
+      </div>
+      <div className="flex flex-col gap-2">
+        <Heading level={3}>{t('what_do_we_do_heading')}</Heading>
+        <Paragraph>{t('what_do_we_do_description')}</Paragraph>
+      </div>
+      <Button appearance="primary-action-button" onClick={() => resetState()}>
+        {t('new_notification')}
+      </Button>
+    </div>
+  )
+}

--- a/src/app/[locale]/incident/thankyou/page.tsx
+++ b/src/app/[locale]/incident/thankyou/page.tsx
@@ -1,40 +1,23 @@
-'use client'
-
-import { useTranslations } from 'next-intl'
-import { Paragraph, Heading } from '@/components/index'
-import { Button, PreserveData } from '@utrecht/component-library-react'
 import React from 'react'
-import { stepToPath, useRouter } from '@/routing/navigation'
-import { FormStep } from '@/types/form'
-import { useFormStore } from '@/store/form_store'
+import { Metadata } from 'next/types'
+import { getServerConfig } from '@/services/config/config'
+import { getTranslations } from 'next-intl/server'
+import { createTitle } from '@/lib/utils/create-title'
+import { ThankyouContent } from '@/app/[locale]/incident/thankyou/components/ThankyouContent'
+
+export async function generateMetadata(): Promise<Metadata> {
+  const config = await getServerConfig()
+  const t = await getTranslations('describe_thankyou')
+  const tGeneral = await getTranslations('general.form')
+
+  return {
+    title: createTitle(
+      [t('heading'), config.base.naam],
+      tGeneral('title_separator')
+    ),
+  }
+}
 
 export default function Thankyou() {
-  const t = useTranslations('describe_thankyou')
-  const { resetForm, formState } = useFormStore()
-  const router = useRouter()
-
-  const resetState = () => {
-    resetForm()
-    router.push(stepToPath[FormStep.STEP_1_DESCRIPTION])
-  }
-
-  return (
-    <div className="flex flex-col gap-8">
-      <Heading level={1}>{t('heading')}</Heading>
-      <div className="flex flex-col gap-2">
-        <Paragraph>
-          {t('description_notification_number')}
-          <PreserveData> {formState.sig_number}</PreserveData>
-        </Paragraph>
-        <Paragraph>{t('description_notification_email')}</Paragraph>
-      </div>
-      <div className="flex flex-col gap-2">
-        <Heading level={3}>{t('what_do_we_do_heading')}</Heading>
-        <Paragraph>{t('what_do_we_do_description')}</Paragraph>
-      </div>
-      <Button appearance="primary-action-button" onClick={() => resetState()}>
-        {t('new_notification')}
-      </Button>
-    </div>
-  )
+  return <ThankyouContent />
 }

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -31,6 +31,7 @@ export {
   LinkButton,
   AlertDialog,
   Article,
+  PreserveData,
   Select,
 } from '@utrecht/component-library-react/dist/css-module'
 

--- a/translations/en.json
+++ b/translations/en.json
@@ -10,7 +10,7 @@
       "describe_upload_heading": "Add photos",
       "describe_upload_description": "Add a photo to clarify the situation (maximum of 5 photos).",
       "errors": {
-        "textarea_required": "Input error: enter what the notification is about",
+        "textarea_required": "Input error: enter what the report is about",
         "file_type_invalid": "Input error: invalid file type. Only JPEG, PNG, and GIF are accepted.",
         "file_size_too_large": "Input error: file size too large. Each file must be less than 20MB.",
         "file_size_too_small": "Input error: file size too small. Each file must be at least 30KB."
@@ -89,12 +89,12 @@
     }
   },
   "describe_thankyou": {
-    "heading": "Thank you!",
-    "description_notification_number": "Your notification is registered with us under number:",
-    "description_notification_email": "Did you provide an email address? You will receive an email with all the details of your notification.",
-    "what_do_we_do_heading": "What do we do with your notification?",
-    "what_do_we_do_description": "Your notification is scheduled: we will inform you within 5 working days about how and when your notification will be handled. We will do this via email.",
-    "new_notification": "New notification"
+    "heading": "Report submitted",
+    "description_notification_number": "Your report is registered with us under number:",
+    "description_notification_email": "Did you provide an email address? You will receive an email with all the details of your report.",
+    "what_do_we_do_heading": "What do we do with your report?",
+    "what_do_we_do_description": "Your report is scheduled: we will inform you within 5 working days about how and when your report will be handled. We will do this via email.",
+    "new_notification": "New report"
   },
   "general": {
     "form": {

--- a/translations/nl.json
+++ b/translations/nl.json
@@ -89,7 +89,7 @@
     }
   },
   "describe_thankyou": {
-    "heading": "Bedankt!",
+    "heading": "Melding verzonden",
     "description_notification_number": "Uw melding is bij ons bekend onder nummer:",
     "description_notification_email": "Hebt u een e-mailadres ingevuld? Dan ontvangt u een e-mail met alle gegevens van uw melding.",
     "what_do_we_do_heading": "Wat doen we met uw melding?",


### PR DESCRIPTION
This fixes #243: 

- Consistent naming in english (changed notification to report, since we decided to use the word report instead of notification).
- Fix title for thankyou page