### PR TITLE
a11y: fix focus ring combobox

### DIFF
--- a/src/components/ui/AddressCombobox.tsx
+++ b/src/components/ui/AddressCombobox.tsx
@@ -115,7 +115,7 @@ export const AddressCombobox = ({
         aria-label="Adres"
         displayValue={(address: any) => address?.weergave_naam}
         onChange={(event) => setQuery(event.target.value)}
-        className={'utrecht-textbox utrecht-textbox--html'}
+        className={'utrecht-textbox utrecht-textbox--html-input'}
         onKeyDown={(e) => handleEnter(e)}
         autoComplete={'off'}
       />


### PR DESCRIPTION
Fix #227 

- Focus ring combobox is now consistent with other focus rings in the application