### PR TITLE
Refactor/225 Alert to SpotlightSection Component

### DIFF
--- a/src/app/[locale]/incident/components/IncidentDescriptionPage.tsx
+++ b/src/app/[locale]/incident/components/IncidentDescriptionPage.tsx
@@ -3,7 +3,7 @@
 import { useTranslations } from 'next-intl'
 import { useFormStore } from '@/store/form_store'
 import { Heading, HeadingGroup, PreHeading } from '@/components'
-import { Alert } from '@/components'
+import { SpotlightSection } from '@/components'
 import { IncidentDescriptionForm } from '@/app/[locale]/incident/components/IncidentDescriptionForm'
 import FormProgress from '@/app/[locale]/components/FormProgress'
 import { useConfig } from '@/hooks/useConfig'
@@ -34,9 +34,9 @@ export const IncidentDescriptionPage = () => {
             </HeadingGroup>
           </FormProgress>
           {config ? (
-            <Alert>
+            <SpotlightSection type="info">
               <RenderMarkdown text={t('alert.help_text')} />
-            </Alert>
+            </SpotlightSection>
           ) : null}
           <IncidentDescriptionForm />
         </div>

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -32,6 +32,7 @@ export {
   AlertDialog,
   Article,
   Select,
+  SpotlightSection,
 } from '@utrecht/component-library-react/dist/css-module'
 
 export { RadioGroup } from '@utrecht/radio-group-react'


### PR DESCRIPTION
**Hoort bij issue #225** 
-
**In deze PR**
* `<SpotlightSection>` Component toevoegen aan `index.ts`
* <Alert> Component wisselen voor `<SpotlightSection>` Component op `IncidentDescriptionPage.tsx`

<img width="500" alt="Scherm­afbeelding 2024-12-12 om 10 19 03" src="https://github.com/user-attachments/assets/a4c3ba19-a477-4ef4-9293-dc0b916d1e57" />

⚠️ Contrast issue #241 is "opgelost". Door gebruik van SpotlightSection is de Alert styling komen te vervallen en daarmee ook de contrast issues. SpotlightSection styling moet nog wel toegevoegd worden. @Marwaxhello voegt deze tokens toe aan het Purmerend thema, zij let hierbij gelijk op contrast. 💪🏼 







