### PR TITLE
Add link text decoration color to globals.css 

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -142,6 +142,7 @@
 .utrecht-link {
   --utrecht-link-color: currentColor;
   --utrecht-link-hover-color: black;
+  --utrecht-link-text-decoration-color: currentColor;
 }
 
 /* colors */
@@ -214,14 +215,20 @@
 }
 
 .dashed-focus:focus-visible {
-      --_utrecht-focus-ring-box-shadow: 0 0 0 var(--utrecht-focus-outline-width, 0) var(--utrecht-focus-inverse-outline-color, transparent);
-    box-shadow: var(--_utrecht-focus-ring-box-shadow);
-    outline-color: var(--utrecht-focus-outline-color, revert);
-    outline-offset: var(--utrecht-focus-outline-offset, revert);
-    outline-style: var(--utrecht-focus-outline-style, revert);
-    outline-width: var(--utrecht-focus-outline-width, revert);
-    z-index: 1;
-    --_utrecht-link-state-text-decoration: var(--utrecht-link-focus-visible-text-decoration, var(--utrecht-link-focus-text-decoration));
-    --_utrecht-link-state-text-decoration-thickness: var(--utrecht-link-focus-visible-text-decoration-thickness, var(--utrecht-link-focus-text-decoration-thickness));
-
+  --_utrecht-focus-ring-box-shadow: 0 0 0 var(--utrecht-focus-outline-width, 0)
+    var(--utrecht-focus-inverse-outline-color, transparent);
+  box-shadow: var(--_utrecht-focus-ring-box-shadow);
+  outline-color: var(--utrecht-focus-outline-color, revert);
+  outline-offset: var(--utrecht-focus-outline-offset, revert);
+  outline-style: var(--utrecht-focus-outline-style, revert);
+  outline-width: var(--utrecht-focus-outline-width, revert);
+  z-index: 1;
+  --_utrecht-link-state-text-decoration: var(
+    --utrecht-link-focus-visible-text-decoration,
+    var(--utrecht-link-focus-text-decoration)
+  );
+  --_utrecht-link-state-text-decoration-thickness: var(
+    --utrecht-link-focus-visible-text-decoration-thickness,
+    var(--utrecht-link-focus-text-decoration-thickness)
+  );
 }


### PR DESCRIPTION
**In deze PR:**

* toevoegen van `--utrecht-link-text-decoration-color: currentColor;` aan `globals.css` zodat de underline van een link in het Alert Component ook mee verandert bij hover & focus.

**Before**
<img width="115" alt="Scherm­afbeelding 2024-12-12 om 15 12 54" src="https://github.com/user-attachments/assets/02a5210a-b8f1-41d6-9cbc-e325b1ebd9b4" />
<img width="125" alt="Scherm­afbeelding 2024-12-13 om 11 35 13" src="https://github.com/user-attachments/assets/a5e7f798-96f1-4010-862b-1b8da89e2832" />

**After**
<img width="128" alt="Scherm­afbeelding 2024-12-13 om 11 35 34" src="https://github.com/user-attachments/assets/199b1856-dede-4961-a585-dcd4cc94c419" />
<img width="112" alt="Scherm­afbeelding 2024-12-13 om 11 35 29" src="https://github.com/user-attachments/assets/7c725c73-a025-4e08-a156-258f96823086" />

