### PR TITLE
feat: add error time to submit alert

### DIFF
--- a/src/app/[locale]/incident/summary/components/SubmitAlert.tsx
+++ b/src/app/[locale]/incident/summary/components/SubmitAlert.tsx
@@ -1,4 +1,4 @@
-import { useTranslations } from 'next-intl'
+import { useLocale, useTranslations } from 'next-intl'
 import React, { useEffect, useRef } from 'react'
 import {
   Alert,
@@ -14,6 +14,7 @@ export const SubmitAlert = ({
   loading: boolean
 }) => {
   const t = useTranslations('describe_summary')
+  const locale = useLocale()
   const alertRef = useRef<HTMLDivElement | null>(null)
   const multilineRef = useRef<HTMLPreElement>(null)
 
@@ -40,7 +41,12 @@ export const SubmitAlert = ({
       <Alert ref={alertRef} type="error" id="submit-described-by">
         <Heading level={3}>{t('submit_alert.error.heading')}</Heading>
         <Paragraph className="pt-2">
-          {t('submit_alert.error.description')}
+          {t('submit_alert.error.description', {
+            time: new Intl.DateTimeFormat(locale, {
+              hour: 'numeric',
+              minute: 'numeric',
+            }).format(new Date()),
+          })}
         </Paragraph>
       </Alert>
     )

--- a/translations/en.json
+++ b/translations/en.json
@@ -85,7 +85,7 @@
     "submit_alert": {
       "error": {
         "heading": "Submit failed",
-        "description": "Due to a technical error, the report could not be sent. We did not receive your information. Please try again in a few minutes."
+        "description": "Due to a technical error, the report could not be sent. We did not receive your information. The time is now {time}. Please try again in a few minutes."
       },
       "loading": {
         "heading": "Processing",

--- a/translations/nl.json
+++ b/translations/nl.json
@@ -85,7 +85,7 @@
     "submit_alert": {
       "error": {
         "heading": "Versturen mislukt",
-        "description": "Wegens een technische fout kon de melding niet worden verzonden. We hebben uw gegevens niet ontvangen. Probeer het over een paar minuten opnieuw."
+        "description": "Wegens een technische fout kon de melding niet worden verzonden. We hebben uw gegevens niet ontvangen. Het is nu {time}. Probeer het over een paar minuten opnieuw."
       },
       "loading": {
         "heading": "Bezig met afhandelen",


### PR DESCRIPTION
Het viel me op dat de alert message niet veranderde als je na een foutmelding voor de tweede keer op submit klikt, na de suggestie van enkele minuten wachten.

Op deze manier weet je zeker dat je tweede submit heeft gewerkt.