### PR TITLE
fix: react error step two (checkbox value), and validation on all dyn…

### DIFF
--- a/src/app/[locale]/incident/add/components/IncidentQuestionsLocationForm.tsx
+++ b/src/app/[locale]/incident/add/components/IncidentQuestionsLocationForm.tsx
@@ -23,6 +23,20 @@ export const IncidentQuestionsLocationForm = () => {
     resolver: (values) => {
       const errors: Record<string, any> = {}
 
+      // Required fields validation
+      Object.keys(values).forEach((key) => {
+        const question = additionalQuestions.find(
+          (question) => question.key === key
+        )
+
+        if (!values[key] && question?.required) {
+          errors[key] = {
+            type: 'required',
+            message: t('required'),
+          }
+        }
+      })
+
       // Location validation
       if (
         !isCoordinates(formStoreState.coordinates) ||

--- a/src/app/[locale]/incident/add/components/questions/RadioInput.tsx
+++ b/src/app/[locale]/incident/add/components/questions/RadioInput.tsx
@@ -3,7 +3,7 @@ import { useTranslations } from 'next-intl'
 import { QuestionField } from '@/types/form'
 import { getValidators } from '@/lib/utils/form-validator'
 import { useFormContext } from 'react-hook-form'
-import { RadioGroup } from '@/components/index'
+import { RadioGroupNLDS } from '@/components/ui/RadioGroupNLDS'
 
 interface RadioGroupProps extends QuestionField {}
 
@@ -18,7 +18,7 @@ export const RadioInput = ({ field }: RadioGroupProps) => {
   const errorMessage = errors[field.key]?.message as string
 
   return (
-    <RadioGroup
+    <RadioGroupNLDS
       label={`${field.meta.label} ${field.required ? `(${tForm('required_short')})` : `(${tForm('not_required_short')})`}`}
       required={field.required}
       id={`${field.key}`}
@@ -36,6 +36,6 @@ export const RadioInput = ({ field }: RadioGroupProps) => {
       invalid={Boolean(errorMessage)}
       errorMessage={errorMessage}
       description={field.meta.subtitle}
-    ></RadioGroup>
+    ></RadioGroupNLDS>
   )
 }

--- a/src/app/[locale]/incident/add/components/questions/RenderSingleField.tsx
+++ b/src/app/[locale]/incident/add/components/questions/RenderSingleField.tsx
@@ -96,9 +96,10 @@ export const RenderSingleField = ({ field }: { field: PublicQuestion }) => {
     if (typeof extraProperty.answer !== 'string') {
       // If the answer is an array (of selected checkboxes), map selected IDs
       const selectedAnswers =
-        typeof extraProperty.answer !== 'string'
+        // @ts-ignore
+        typeof extraProperty.answer !== 'string' && extraProperty.answer.length
           ? // @ts-ignore
-            extraProperty.answer.map((answer: any) => answer?.id)
+            extraProperty.answer?.map((answer: any) => answer?.id)
           : []
 
       // Generate the array as expected by react-hook-form, based on options

--- a/src/components/ui/RadioGroupNLDS.tsx
+++ b/src/components/ui/RadioGroupNLDS.tsx
@@ -1,0 +1,133 @@
+import { Fieldset, FieldsetLegend } from '@utrecht/fieldset-react'
+import { FormFieldDescription } from '@utrecht/form-field-description-react'
+import { FormFieldErrorMessage } from '@utrecht/form-field-error-message-react'
+import type { FormFieldProps } from '@utrecht/form-field-react'
+import type { RadioButtonProps } from '@utrecht/radio-button-react'
+import clsx from 'clsx'
+import {
+  ForwardedRef,
+  forwardRef,
+  PropsWithChildren,
+  ReactNode,
+  Ref,
+  useId,
+} from 'react'
+import { RadioOptionNLDS } from '@/components/ui/RadioOptionNLDS'
+
+export interface RadioGroupOptionProps
+  extends Pick<
+      RadioButtonProps,
+      | 'defaultValue'
+      | 'value'
+      | 'checked'
+      | 'defaultChecked'
+      | 'defaultValue'
+      | 'disabled'
+      | 'invalid'
+      | 'name'
+      | 'required'
+      | 'value'
+    >,
+    Pick<FormFieldProps, 'id' | 'label' | 'description' | 'errorMessage'> {
+  inputRef?: Ref<HTMLInputElement>
+}
+export interface RadioGroupProps
+  extends Omit<FormFieldProps, 'type' | 'invalid'>,
+    Pick<
+      RadioButtonProps,
+      'disabled' | 'invalid' | 'name' | 'required' | 'value'
+    > {
+  description?: ReactNode
+  errorMessage?: ReactNode
+  inputRef?: Ref<HTMLInputElement>
+  label: ReactNode
+  status?: ReactNode
+  options?: RadioGroupOptionProps[]
+}
+
+export const RadioGroupNLDS = forwardRef(
+  (
+    {
+      children,
+      className,
+      defaultValue,
+      description,
+      disabled,
+      errorMessage,
+      inputRef,
+      invalid,
+      label,
+      name,
+      onBlur,
+      onChange,
+      onFocus,
+      onInput,
+      required,
+      status,
+      value,
+      options,
+      ...props
+    }: PropsWithChildren<RadioGroupProps>,
+    ref: ForwardedRef<HTMLDivElement>
+  ) => {
+    const descriptionId = useId()
+    const errorMessageId = useId()
+    const statusId = useId()
+
+    return (
+      <Fieldset
+        role="radiogroup"
+        className={clsx('utrecht-radio-group', className)}
+        invalid={invalid}
+        required={required}
+        aria-describedby={
+          clsx(descriptionId, errorMessageId, statusId) || undefined
+        }
+        ref={ref}
+        {...props}
+      >
+        <FieldsetLegend className="utrecht-radio-group__label">
+          {label}
+        </FieldsetLegend>
+        {description && (
+          <FormFieldDescription
+            className="utrecht-radio-group__description"
+            id={descriptionId}
+          >
+            {description}
+          </FormFieldDescription>
+        )}
+        {invalid && errorMessage && (
+          <FormFieldErrorMessage
+            className="utrecht-radio-group__error-message"
+            id={errorMessageId}
+          >
+            {errorMessage}
+          </FormFieldErrorMessage>
+        )}
+        {Array.isArray(options)
+          ? options.map(({ ...props }, index) => (
+              <RadioOptionNLDS
+                key={index}
+                name={name}
+                disabled={disabled}
+                onChange={onChange}
+                onInput={onInput}
+                onFocus={onFocus}
+                onBlur={onBlur}
+                {...props}
+              />
+            ))
+          : null}
+        {children}
+        {status && (
+          <div className="utrecht-radio-group__status" id={statusId}>
+            {status}
+          </div>
+        )}
+      </Fieldset>
+    )
+  }
+)
+
+RadioGroupNLDS.displayName = 'RadioGroupNLDS'

--- a/src/components/ui/RadioOptionNLDS.tsx
+++ b/src/components/ui/RadioOptionNLDS.tsx
@@ -1,0 +1,121 @@
+import { FormFieldDescription } from '@utrecht/form-field-description-react'
+import { FormFieldErrorMessage } from '@utrecht/form-field-error-message-react'
+import { FormField, type FormFieldProps } from '@utrecht/form-field-react'
+import { FormLabel } from '@utrecht/form-label-react'
+import { RadioButton, type RadioButtonProps } from '@utrecht/radio-button-react'
+import clsx from 'clsx'
+import { ForwardedRef, forwardRef, PropsWithChildren, Ref, useId } from 'react'
+
+export interface RadioOptionProps
+  extends Omit<
+      FormFieldProps,
+      | 'defaultChecked'
+      | 'defaultValue'
+      | 'defaultValue'
+      | 'invalid'
+      | 'onBlur'
+      | 'onChange'
+      | 'onFocus'
+      | 'onInput'
+    >,
+    Pick<
+      RadioButtonProps,
+      | 'checked'
+      | 'defaultChecked'
+      | 'defaultValue'
+      | 'defaultValue'
+      | 'disabled'
+      | 'invalid'
+      | 'name'
+      | 'onBlur'
+      | 'onChange'
+      | 'onFocus'
+      | 'onInput'
+      | 'required'
+      | 'value'
+      | 'value'
+    > {
+  inputRef?: Ref<HTMLInputElement>
+}
+
+export const RadioOptionNLDS = forwardRef(
+  (
+    {
+      checked,
+      children,
+      defaultChecked,
+      defaultValue,
+      description,
+      disabled,
+      errorMessage,
+      inputRef,
+      invalid,
+      label,
+      name,
+      onBlur,
+      onChange,
+      onFocus,
+      onInput,
+      required,
+      value,
+      ...props
+    }: PropsWithChildren<RadioOptionProps>,
+    ref: ForwardedRef<HTMLDivElement>
+  ) => {
+    const inputId = useId()
+    const descriptionId = useId()
+    const errorMessageId = useId()
+
+    return (
+      <FormField invalid={invalid} type="radio" ref={ref} {...props}>
+        <div className="utrecht-form-field__label utrecht-form-field__label--radio">
+          <FormLabel type="radio" htmlFor={inputId}>
+            <RadioButton
+              aria-describedby={
+                clsx({
+                  [descriptionId]: description,
+                  [errorMessageId]: invalid,
+                }) || undefined
+              }
+              checked={checked}
+              className="utrecht-form-field__input"
+              defaultChecked={defaultChecked}
+              defaultValue={defaultValue}
+              disabled={disabled}
+              id={inputId}
+              ref={inputRef}
+              invalid={invalid}
+              name={name}
+              onBlur={onBlur}
+              onChange={onChange}
+              onFocus={onFocus}
+              onInput={onInput}
+              required={required}
+              value={value}
+            />
+            {label}
+          </FormLabel>
+        </div>
+        {description && (
+          <FormFieldDescription
+            className="utrecht-form-field__description"
+            id={descriptionId}
+          >
+            {description}
+          </FormFieldDescription>
+        )}
+        {invalid && errorMessage && (
+          <FormFieldErrorMessage
+            className="utrecht-form-field__error-message"
+            id={errorMessageId}
+          >
+            {errorMessage}
+          </FormFieldErrorMessage>
+        )}
+        {children}
+      </FormField>
+    )
+  }
+)
+
+RadioOptionNLDS.displayName = 'RadioOptionNLDS'


### PR DESCRIPTION
fixes two problems:

- sometimes an error showed up by navigating back to step two, this had something to do with getting the default checkbox value.
- add default required / non required validation to all fields in custom react hook form validator, without this fields except the location field are not getting validated.
- we initially thought the issue with the required radio group was due to a problem in the library, but it turned out to be caused by our own codebase. Unfortunately, we introduced a fix in utrecht/radio-group-react that not only failed to resolve the issue but also caused further problems by adding required={required} to the RadioOption. So this PR fixes this with an own RadioGroup component (so that this is not an issue in the test anymore)