### PR TITLE
feat: scroll checkbox/radio label into view

### DIFF
--- a/src/app/[locale]/incident/add/components/FeatureListItem.tsx
+++ b/src/app/[locale]/incident/add/components/FeatureListItem.tsx
@@ -122,6 +122,16 @@ export const FeatureListItem = ({
           id={featureId.toString()}
           // @ts-ignore
           onChange={(e) => addOrRemoveFeature(e.target.checked)}
+          onFocus={(evt) => {
+            const label = evt.target.closest('label')
+            if (label) {
+              label.scrollIntoView({
+                behavior: 'smooth',
+                block: 'nearest',
+                inline: 'nearest',
+              })
+            }
+          }}
         />
       </FormField>
     </li>

--- a/src/app/[locale]/incident/add/components/questions/CheckboxInput.tsx
+++ b/src/app/[locale]/incident/add/components/questions/CheckboxInput.tsx
@@ -4,6 +4,7 @@ import { getValidators } from '@/lib/utils/form-validator'
 import React from 'react'
 import { useFormContext } from 'react-hook-form'
 import { CheckboxGroup } from '@/components/index'
+import type { FocusEvent } from 'react'
 
 interface CheckboxInputProps extends QuestionField {}
 
@@ -31,6 +32,16 @@ export const CheckboxInput = ({ field }: CheckboxInputProps) => {
           label: field.meta.values[key],
           value: key,
           id: `${field.key}-${key}`,
+          onFocus: (evt: FocusEvent<HTMLInputElement>) => {
+            const label = evt.target.closest('label')
+            if (label) {
+              label.scrollIntoView({
+                behavior: 'smooth',
+                block: 'nearest',
+                inline: 'nearest',
+              })
+            }
+          },
         }
       })}
       invalid={Boolean(errorMessage)}

--- a/src/app/[locale]/incident/add/components/questions/RadioInput.tsx
+++ b/src/app/[locale]/incident/add/components/questions/RadioInput.tsx
@@ -36,6 +36,16 @@ export const RadioInput = ({ field }: RadioGroupProps) => {
       invalid={Boolean(errorMessage)}
       errorMessage={errorMessage}
       description={field.meta.subtitle}
+      onFocus={(evt) => {
+        const label = evt.target.closest('label')
+        if (label) {
+          label.scrollIntoView({
+            behavior: 'smooth',
+            block: 'nearest',
+            inline: 'nearest',
+          })
+        }
+      }}
     ></RadioGroupNLDS>
   )
 }


### PR DESCRIPTION
Currently the focus only makes sure the radio button or checkbox itself is in view, but this code:

- makes sure the label for the radio button / checkbox is in view
- makes sure there is no unecessary scrolling then the label is already visible

This is particularly useful for the dialog in step 2 at 400% zoom