### PR TITLE
feat: add lat/lon coordinates to map labels

### DIFF
--- a/src/lib/utils/format-coordinates.ts
+++ b/src/lib/utils/format-coordinates.ts
@@ -1,0 +1,89 @@
+type CoordinatesTuple = [number, number]
+
+export interface DegreeMinuteSecond {
+  degree: number
+  minute: number
+  second: number
+}
+
+export interface DegreeMinuteSecondCoordinates {
+  latitude: DegreeMinuteSecond & {
+    north: boolean
+    south: boolean
+  }
+  longitude: DegreeMinuteSecond & {
+    east: boolean
+    west: boolean
+  }
+}
+
+/**
+ * From: https://stackoverflow.com/posts/5786281
+ */
+export const degreeMinuteSecond = (d: number): DegreeMinuteSecond => {
+  let degree = Math.abs(Math.floor(d)),
+    minute = Math.abs(Math.floor(((d + 1e-9) % 1) * 60)),
+    second = Math.abs(Math.floor(((((d + 1e-9) * 60) % 1) * 6000) / 100))
+
+  return {
+    degree,
+    minute,
+    second,
+  }
+}
+
+export const coords2degreeMinuteSeconds = ([latitude, longitude]: [
+  number,
+  number,
+]) => {
+  return {
+    latitude: {
+      ...degreeMinuteSecond(latitude),
+      north: latitude >= 0,
+      south: latitude < 0,
+    },
+    longitude: {
+      ...degreeMinuteSecond(longitude),
+      east: longitude >= 0,
+      west: longitude < 0,
+    },
+  }
+}
+
+export const coords2degreeMinuteSecondsFlat = (coords: [number, number]) => {
+  const {
+    latitude: {
+      degree: latitudeDegree,
+      minute: latitudeMinute,
+      second: latitudeSecond,
+      south,
+      north,
+    },
+    longitude: {
+      degree: longitudeDegree,
+      minute: longitudeMinute,
+      second: longitudeSecond,
+      east,
+      west,
+    },
+  } = coords2degreeMinuteSeconds(coords)
+
+  return {
+    latitudeDegree,
+    latitudeMinute,
+    latitudeSecond,
+    longitudeDegree,
+    longitudeMinute,
+    longitudeSecond,
+    north,
+    south,
+    east,
+    west,
+  }
+}
+
+export const isCoordinatesTuple = (arg: any): arg is CoordinatesTuple =>
+  Array.isArray(arg) &&
+  arg.length === 2 &&
+  typeof arg[0] === 'number' &&
+  typeof arg[1] === 'number'

--- a/translations/en.json
+++ b/translations/en.json
@@ -128,7 +128,19 @@
         "heading": "Processing",
         "description": "Your report is being processed. You will automatically go to the next page once the report is received.\n\nPlease wait a moment...."
       }
-    }
+    },
+    "map_coords": "map zoomed into {coords}",
+    "coords": "{latitudeDegrees} {latitudeMinutes} {latitudeDescription}, {longitudeDegrees} {longitudeMinutes} {longitudeDescription}",
+    "north": "North",
+    "south": "South",
+    "east": "East",
+    "west": "West",
+    "degree_long": " degrees",
+    "minute_long": " minutes",
+    "second_long": " seconds",
+    "degree_short": "°",
+    "minute_short": "′",
+    "second_short": "″"
   },
   "describe_thankyou": {
     "heading": "Report submitted",

--- a/translations/nl.json
+++ b/translations/nl.json
@@ -128,7 +128,19 @@
         "heading": "Bezig met afhandelen",
         "description": "Uw melding wordt afgehandeld. U gaat automatisch naar de volgende pagina zodra de melding is ontvangen.\n\nEen ogenblik geduld alstublieft..."
       }
-    }
+    },
+    "coords": "{latitudeDegree}{degreeSuffix} {latitudeMinute}{minuteSuffix} {latitudeDescription}, {longitudeDegree}{degreeSuffix} {longitudeMinute}{minuteSuffix} {longitudeDescription}",
+    "map_coords": "kaart ingezoomd op {coords}",
+    "north": "noorderbreedte",
+    "south": "zuiderbreedte",
+    "east": "oosterlengte",
+    "west": "westerlengte",
+    "degree_long": " graden",
+    "minute_long": " minuten",
+    "second_long": " seconden",
+    "degree_short": "°",
+    "minute_short": "′",
+    "second_short": "″"
   },
   "describe_thankyou": {
     "heading": "Melding verzonden",


### PR DESCRIPTION
This will be quite useful for end-to-end tests too.

I'm hoping to refactor this in another PR, to be able to use for other maps in the application too.