### PR TITLE
feat: configure reactive map zoom with out without address

### DIFF
--- a/config.json
+++ b/config.json
@@ -28,7 +28,8 @@
       "maxBounds": [
         [3.31497114423, 50.803721015],
         [7.09205325687, 53.5104033474]
-      ]
+      ],
+      "default_zoom": 12
     },
     "links": {
       "about": "https://signalen.org",

--- a/src/app/[locale]/incident/add/components/MapDialog.tsx
+++ b/src/app/[locale]/incident/add/components/MapDialog.tsx
@@ -96,7 +96,9 @@ const MapDialog = ({
   const [viewState, setViewState] = useState<ViewState>({
     latitude: 0,
     longitude: 0,
-    zoom: 18,
+    zoom: formState.address
+      ? config?.base.map.minimal_zoom || 17
+      : config?.base.map.default_zoom || 12,
     bearing: 0,
     padding: {
       top: 0,
@@ -157,10 +159,20 @@ const MapDialog = ({
     }
   }, [features, field])
 
+  useEffect(() => {
+    setViewState((state) => ({
+      ...state,
+      zoom: formState.address
+        ? config?.base.map.minimal_zoom || 17
+        : config?.base.map.default_zoom || 12,
+    }))
+  }, [config, formState])
+
   // memoize list of features to show in left sidebar
   const featureList = useMemo(() => {
     if (config && dialogMap) {
-      const mapFeaturesToShow = mapFeatures ? mapFeatures.features : []
+      const mapFeaturesToShow =
+        mapFeatures && formState.address ? mapFeatures.features : []
 
       const features =
         dialogMap?.getZoom() > config.base.map.minimal_zoom
@@ -171,14 +183,14 @@ const MapDialog = ({
     }
 
     return []
-  }, [config, dialogMap, formState.selectedFeatures, mapFeatures])
+  }, [config, dialogMap, formState, mapFeatures])
 
   // Update position, flyTo position, after this set the marker position
   const updatePosition = (lat: number, lng: number) => {
     if (dialogMap) {
       dialogMap.flyTo({
         center: [lng, lat],
-        zoom: 18,
+        zoom: config?.base.map.minimal_zoom || 17,
       })
     }
 
@@ -552,6 +564,7 @@ const MapDialog = ({
                 {onMapReady &&
                   dialogMap &&
                   dialogMap.getZoom() > config.base.map.minimal_zoom &&
+                  formState.address &&
                   mapFeatures?.features.map((feature) => {
                     const id = feature.id as number
 

--- a/src/components/ui/LocationMap.tsx
+++ b/src/components/ui/LocationMap.tsx
@@ -14,7 +14,9 @@ const LocationMap = () => {
   const [viewState, setViewState] = useState<ViewState>({
     latitude: 0,
     longitude: 0,
-    zoom: 14,
+    zoom: formState.address
+      ? config?.base.map.minimal_zoom || 17
+      : config?.base.map.default_zoom || 12,
     bearing: 0,
     padding: {
       top: 0,
@@ -49,12 +51,21 @@ const LocationMap = () => {
 
   // Update viewState, to move map view with marker
   useEffect(() => {
-    setViewState({
-      ...viewState,
+    setViewState((state) => ({
+      ...state,
       latitude: marker[0],
       longitude: marker[1],
-    })
+    }))
   }, [marker])
+
+  useEffect(() => {
+    setViewState((state) => ({
+      ...state,
+      zoom: formState.address
+        ? config?.base.map.minimal_zoom || 17
+        : config?.base.map.default_zoom || 12,
+    }))
+  }, [config, formState])
 
   const mapStyle = isDarkMode
     ? `${process.env.NEXT_PUBLIC_MAPTILER_MAP_DARK_MODE}/style.json?key=${process.env.NEXT_PUBLIC_MAPTILER_API_KEY}`

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -26,6 +26,7 @@ export type AppConfig = {
     map: {
       find_address_in_distance: number
       minimal_zoom: number
+      default_zoom: number
       center: number[]
       maxBounds: number[][]
     }


### PR DESCRIPTION
1. When no address is selected listen to new `map.default_zoom` option or fallback to zoom level 12
2. When an address is selected listen to `map.minimal_zoom` or fallback to zoom level 18
3. Only show map markers and feature list when an address is available in formState
4. Also change zoom level when input in `vulaan` step changes